### PR TITLE
Deny use of ConfigCollection.IList indexer setter

### DIFF
--- a/Source/Config/ConfigCollection.cs
+++ b/Source/Config/ConfigCollection.cs
@@ -81,7 +81,7 @@ namespace Nini.Config
         object IList.this[int index]
         {
             get { return configList[index]; }
-            set {  }
+            set { throw new NotImplementedException ("Not implemented, use Add methods instead"); }
         }
         
         /// <include file='ConfigCollection.xml' path='//Property[@name="ItemName"]/docs/*' />


### PR DESCRIPTION
This will throws an exception if someone tries to call setter method of ConfigCollection.IList indexer implementation, instead of just ignoring the call.
