### PR TITLE
Enhancements to ArgvConfigSource

### DIFF
--- a/Source/Config/ArgvConfigSource.cs
+++ b/Source/Config/ArgvConfigSource.cs
@@ -12,6 +12,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Collections;
+using System.Collections.Generic;
 using Nini.Util;
 
 namespace Nini.Config
@@ -22,13 +23,14 @@ namespace Nini.Config
         #region Private variables
         ArgvParser parser = null;
         string[] arguments = null;
+        List<string> parameterlessArgs = new List<string>();
         #endregion
 
         #region Constructors
         /// <include file='ArgvConfigSource.xml' path='//Constructor[@name="Constructor"]/docs/*' />
         public ArgvConfigSource (string[] arguments)
         {
-            parser = new ArgvParser (arguments);
+            parser = new ArgvParser (arguments, parameterlessArgs);
             this.arguments = arguments;
         }
         #endregion
@@ -57,13 +59,24 @@ namespace Nini.Config
         
         /// <include file='ArgvConfigSource.xml' path='//Method[@name="AddSwitchShort"]/docs/*' />
         public void AddSwitch (string configName, string longName, 
-                                string shortName)
+                                string shortName, bool parameterless = false)
         {
             IConfig config = GetConfig (configName);
             
             if (shortName != null && 
                 (shortName.Length < 1 || shortName.Length > 2)) {
                 throw new ArgumentException ("Short name may only be 1 or 2 characters");
+            }
+
+            if (parameterless)
+            {
+                parameterlessArgs.Add(longName);
+                if (shortName != null)
+                    parameterlessArgs.Add(shortName);
+
+                // Re-parse because there is a new parameterless argument. This will change
+                // the meaning of non-option args
+                parser = new ArgvParser (arguments, parameterlessArgs);
             }
 
             // Look for the long name first

--- a/Source/Config/ArgvConfigSource.cs
+++ b/Source/Config/ArgvConfigSource.cs
@@ -82,6 +82,16 @@ namespace Nini.Config
 
             return result;
         }
+
+        public int GetPositionalArgumentCount()
+        {
+            return parser.Count();
+        }
+
+        public string GetPositionalArgument(int index)
+        {
+            return parser[index];
+        }
         #endregion
 
         #region Private methods

--- a/Source/Nini.sln
+++ b/Source/Nini.sln
@@ -2,8 +2,8 @@ Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nini", "Nini.csproj", "{9B920C90-08EF-4123-A6B7-5F25CF0F94EC}"
 EndProject
-#Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NiniTest", "Test\NiniTest.csproj", "{BF80879B-3F0D-44A8-87FF-00143FDD3D16}"
-#EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NiniTest", "Test\NiniTest.csproj", "{BF80879B-3F0D-44A8-87FF-00143FDD3D16}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/Nini.sln
+++ b/Source/Nini.sln
@@ -2,8 +2,8 @@ Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nini", "Nini.csproj", "{9B920C90-08EF-4123-A6B7-5F25CF0F94EC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NiniTest", "Test\NiniTest.csproj", "{BF80879B-3F0D-44A8-87FF-00143FDD3D16}"
-EndProject
+#Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NiniTest", "Test\NiniTest.csproj", "{BF80879B-3F0D-44A8-87FF-00143FDD3D16}"
+#EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/Util/ArgvParser.cs
+++ b/Source/Util/ArgvParser.cs
@@ -24,6 +24,7 @@ namespace Nini.Util
         #region Private variables
         StringDictionary parameters;
         List<string> positional;
+        List<string> parameterlessArgs;
         #endregion
         
         #region Constructors
@@ -50,8 +51,9 @@ namespace Nini.Util
         }
         
         /// <include file='ArgvParser.xml' path='//Constructor[@name="ConstructorArray"]/docs/*' />
-        public ArgvParser (string[] args)
+        public ArgvParser (string[] args, List<string> paramlessArgs)
         {
+            parameterlessArgs = paramlessArgs;
             Extract (args);
         }
         #endregion
@@ -112,6 +114,12 @@ namespace Nini.Util
                     parameter = part.Groups["name"].Value;
                     parameters.Add (parameter, 
                                     part.Groups["value"].Value.Trim (trimChars));
+                    if (parameterlessArgs != null && parameterlessArgs.Contains(parameter))
+                    {
+                        // Make it true and don't look for an argument
+                        parameters[parameter] = "True";
+                        parameter = null;
+                    }
                 }
             }
         }

--- a/Source/Util/ArgvParser.cs
+++ b/Source/Util/ArgvParser.cs
@@ -85,6 +85,7 @@ namespace Nini.Util
                     // Found a value (for the last parameter found (space separator))
                     if (parameter != null) {
                         parameters[parameter] = arg.Trim (trimChars);
+                        parameter = null;
                     }
                 } else {
                     // Matched a name, optionally with inline value

--- a/Source/Util/ArgvParser.cs
+++ b/Source/Util/ArgvParser.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Text.RegularExpressions;
 
@@ -22,6 +23,7 @@ namespace Nini.Util
     {
         #region Private variables
         StringDictionary parameters;
+        List<string> positional;
         #endregion
         
         #region Constructors
@@ -62,6 +64,21 @@ namespace Nini.Util
                 return parameters[param];
             }
         }
+
+        public string this [int number]
+        {
+            get  {
+                if (number < 0 || number >= positional.Count)
+                    return String.Empty;
+
+                return positional[number];
+            }
+        }
+
+        public int Count()
+        {
+            return positional.Count;
+        }
         #endregion
 
         #region Private methods
@@ -69,6 +86,7 @@ namespace Nini.Util
         private void Extract(string[] args)
         {
             parameters = new StringDictionary();
+            positional = new List<string>();
             Regex splitter = new Regex (@"^([/-]|--){1}(?<name>\w+)([:=])?(?<value>.+)?$",
                                         RegexOptions.Compiled);
             char[] trimChars = {'"','\''};
@@ -86,6 +104,8 @@ namespace Nini.Util
                     if (parameter != null) {
                         parameters[parameter] = arg.Trim (trimChars);
                         parameter = null;
+                    } else {
+                        positional.Add(arg.Trim(trimChars));
                     }
                 } else {
                     // Matched a name, optionally with inline value

--- a/Source/Util/ArgvParser.cs
+++ b/Source/Util/ArgvParser.cs
@@ -43,6 +43,8 @@ namespace Nini.Util
             {
                 parts[i-1] = matches[i].Value.Trim ();
             }
+
+            Extract(parts);
         }
         
         /// <include file='ArgvParser.xml' path='//Constructor[@name="ConstructorArray"]/docs/*' />


### PR DESCRIPTION
This patch fixes the plain string constructor of ArgvParser and introduces access to positional, non-option arguments from the command line without the user having to do their own parsing.
This still doesn't address the concept of parameterless (boolean) options fully.